### PR TITLE
Fix isSupported check on iOS

### DIFF
--- a/ios/ExpoQuickActionsModule.swift
+++ b/ios/ExpoQuickActionsModule.swift
@@ -97,8 +97,12 @@ public class ExpoQuickActionsModule: Module {
         }.runOnQueue(.main)
         
         AsyncFunction("isSupported") { () -> Bool in
-            UIApplication.shared.delegate?.window??
-                .rootViewController?.traitCollection.forceTouchCapability == .available
+            if #available (iOS 13.0, *) {
+                return true
+            } else {
+                return UIApplication.shared.delegate?.window??
+                    .rootViewController?.traitCollection.forceTouchCapability == .available
+            }
         }.runOnQueue(.main)
         
         Events(onQuickAction)


### PR DESCRIPTION
Quick actions should be universally available starting from iOS 13 and as I understand it's not necessary to check for `forceTouchCapability`. According to [this doc](https://developer.apple.com/documentation/uikit/menus_and_shortcuts/add_home_screen_quick_actions#overview): 

> On the Home screen of a device running iOS 13 or later, apps can display Home Screen quick actions ...

This check returns false on simulators, as mentioned in https://github.com/EvanBacon/expo-quick-actions/issues/4.

In this PR I changed the logic of `isSupported` to return `true` on iOS 13+ and fallback to old solution for previous versions, since `forceTouchCapability` is [available from iOS 9.0](https://developer.apple.com/documentation/uikit/uitraitcollection/1623515-forcetouchcapability). 


