### PR TITLE
Fix: set JVM target version with @react-native/gradle-plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,13 +53,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }  
   }
 
   namespace "expo.modules.quickactions"


### PR DESCRIPTION
This seems like this is the proper fix as per https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md#error-task-current-target-is-17-and-compilereleasekotlin-task-current-target-is-11-jvm-target-compatibility-should-be-set-to-the-same-java-version

