### PR TITLE
fix(example): make android app work, add apple-colors to the config

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -82,7 +82,8 @@
           "backgroundColor": "#ffffff",
           "enableFullScreenImage_legacy": true
         }
-      ]
+      ],
+      ["@bacons/apple-colors"]
     ],
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
Hello @EvanBacon 👋, this pr fixes the error while running the android version of the example because apple colors where not configured 