### PR TITLE
chore: rename async function call for QuickActions support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ QuickActions.setItems([
 An async function that returns whether the device supports home screen quick actions.
 
 ```ts
-const isSupported = await QuickActions.isSupportedAsync();
+const isSupported = await QuickActions.isSupported();
 ```
 
 ### `addListener`


### PR DESCRIPTION
**Why**

The docs were outdated, the function is no longer called `isSupportedAsync`, its called `isSupported`

**Screenshot**

The TS error I got when I followed the docs:

<img width="1202" height="416" alt="Screenshot 2025-08-28 at 11 02 44 AM" src="https://github.com/user-attachments/assets/622fc3d2-79a8-4901-95c7-b4da9ff09450" />
